### PR TITLE
Branch: shell-file-refactor no longer exists

### DIFF
--- a/centos-6.5-x86_64-netboot/scripts/puphpet.sh
+++ b/centos-6.5-x86_64-netboot/scripts/puphpet.sh
@@ -5,10 +5,10 @@ useradd -g www-data www-data
 
 mkdir -p '/.puphpet-stuff/shell'
 
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
 
 chmod +x '/.puphpet-stuff/shell/os-detect.sh'
 chmod +x '/.puphpet-stuff/shell/initial-setup.sh'

--- a/debian-7.5-x86-netboot/scripts/puphpet.sh
+++ b/debian-7.5-x86-netboot/scripts/puphpet.sh
@@ -5,10 +5,10 @@ useradd -g www-data www-data
 
 mkdir -p '/.puphpet-stuff/shell'
 
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
 
 chmod +x '/.puphpet-stuff/shell/os-detect.sh'
 chmod +x '/.puphpet-stuff/shell/initial-setup.sh'

--- a/debian-7.5-x86_64-netboot/scripts/puphpet.sh
+++ b/debian-7.5-x86_64-netboot/scripts/puphpet.sh
@@ -5,10 +5,10 @@ useradd -g www-data www-data
 
 mkdir -p '/.puphpet-stuff/shell'
 
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
 
 chmod +x '/.puphpet-stuff/shell/os-detect.sh'
 chmod +x '/.puphpet-stuff/shell/initial-setup.sh'

--- a/ubuntu-12.04-x86_64/scripts/puphpet.sh
+++ b/ubuntu-12.04-x86_64/scripts/puphpet.sh
@@ -5,10 +5,10 @@ useradd -g www-data www-data
 
 mkdir -p '/.puphpet-stuff/shell'
 
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
 
 chmod +x '/.puphpet-stuff/shell/os-detect.sh'
 chmod +x '/.puphpet-stuff/shell/initial-setup.sh'

--- a/ubuntu-14.04-x86_64/scripts/puphpet.sh
+++ b/ubuntu-14.04-x86_64/scripts/puphpet.sh
@@ -5,10 +5,10 @@ useradd -g www-data www-data
 
 mkdir -p '/.puphpet-stuff/shell'
 
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
-wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/shell-file-refactor/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/os-detect.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/initial-setup.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-ruby.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh'
+wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate  -O '/.puphpet-stuff/shell/install-puppet.sh' 'https://raw.github.com/puphpet/puphpet/master/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-puppet.sh'
 
 chmod +x '/.puphpet-stuff/shell/os-detect.sh'
 chmod +x '/.puphpet-stuff/shell/initial-setup.sh'


### PR DESCRIPTION
Updated to link to master, instead of the branch shell-file-refactor. Which no longer exists.
