### PR TITLE
Fixed paths to Parallels Tools ISO

### DIFF
--- a/debian-7-x86/scripts/parallels.sh
+++ b/debian-7-x86/scripts/parallels.sh
@@ -8,10 +8,10 @@ fi
 # Install the Parallels Tools
 
 mkdir -p /mnt/parallels
-mount -o loop /home/vagrant/prl-tools.iso /mnt/parallels
+mount -o loop /home/vagrant/prl-tools-lin.iso /mnt/parallels
 
 /mnt/parallels/install --install-unattended-with-deps --progress
 
 umount /mnt/parallels
 
-rm -rf /home/vagrant/prl-tools.iso
+rm -rf /home/vagrant/prl-tools-lin.iso

--- a/debian-7-x86_64/scripts/parallels.sh
+++ b/debian-7-x86_64/scripts/parallels.sh
@@ -8,10 +8,10 @@ fi
 # Install the Parallels Tools
 
 mkdir -p /mnt/parallels
-mount -o loop /home/vagrant/prl-tools.iso /mnt/parallels
+mount -o loop /home/vagrant/prl-tools-lin.iso /mnt/parallels
 
 /mnt/parallels/install --install-unattended-with-deps --progress
 
 umount /mnt/parallels
 
-rm -rf /home/vagrant/prl-tools.iso
+rm -rf /home/vagrant/prl-tools-lin.iso

--- a/ubuntu-12.04-x86_64/scripts/parallels.sh
+++ b/ubuntu-12.04-x86_64/scripts/parallels.sh
@@ -8,10 +8,10 @@ fi
 # Install the Parallels Tools
 
 mkdir -p /mnt/parallels
-mount -o loop /home/vagrant/prl-tools.iso /mnt/parallels
+mount -o loop /home/vagrant/prl-tools-lin.iso /mnt/parallels
 
 /mnt/parallels/install --install-unattended-with-deps --progress
 
 umount /mnt/parallels
 
-rm -rf /home/vagrant/prl-tools.iso
+rm -rf /home/vagrant/prl-tools-lin.iso


### PR DESCRIPTION
By default Parallels Tools ISO is saved as `prl-tools-lin.iso` unless it is overridden by ["parallels_tools_guest_path"](https://packer.io/docs/builders/parallels-iso.html#parallels_tools_guest_path) option in the `template.json`.

So, currently 'debian-7-x86', 'debian-7-x86_64' and 'ubuntu-12.04-x86_64' have wrong iso names there and Parallels Tools are not installed. 

Please, merge this PR and rebuild boxes mentioned above for "parallels" provider, because it is annoyed users of PuPHPet: https://github.com/Parallels/vagrant-parallels/issues/174
