### PR TITLE
Fix for vagrant error: "==> default: stdin: is not a tty"

### DIFF
--- a/ubuntu-14.04-x86/scripts/vagrant.sh
+++ b/ubuntu-14.04-x86/scripts/vagrant.sh
@@ -11,3 +11,6 @@ chown -R vagrant /home/vagrant/.ssh
 
 # Customize the message of the day
 echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd
+
+# Fix for vagrant error: "==> default: stdin: is not a tty"
+sed -i -r -e 's/^([# ]+)?(mesg n)/# \2/' /root/.profile

--- a/ubuntu-14.04-x86_64/scripts/vagrant.sh
+++ b/ubuntu-14.04-x86_64/scripts/vagrant.sh
@@ -11,3 +11,6 @@ chown -R vagrant /home/vagrant/.ssh
 
 # Customize the message of the day
 echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd
+
+# Fix for vagrant error: "==> default: stdin: is not a tty"
+sed -i -r -e 's/^([# ]+)?(mesg n)/# \2/' /root/.profile


### PR DESCRIPTION
Comments out the "mesg n" line in /root/.profile

http://manpages.ubuntu.com/manpages/trusty/man1/mesg.1.html

Fixes https://github.com/puphpet/puphpet/issues/213

Fix similar to https://github.com/mitchellh/vagrant/issues/1673