### PR TITLE
Return to original mirror

### DIFF
--- a/ubuntu-12.04-x86_64/scripts/base.sh
+++ b/ubuntu-12.04-x86_64/scripts/base.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-perl -p -i -e 's#http://us.archive.ubuntu.com/ubuntu#http://mirror.rackspace.com/ubuntu#gi' /etc/apt/sources.list
-
 # Update the box
 apt-get -y update >/dev/null
 apt-get -y install facter linux-headers-$(uname -r) build-essential zlib1g-dev libssl-dev libreadline-gplv2-dev curl unzip >/dev/null

--- a/ubuntu-14.04-x86/scripts/base.sh
+++ b/ubuntu-14.04-x86/scripts/base.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-perl -p -i -e 's#http://us.archive.ubuntu.com/ubuntu#http://mirror.rackspace.com/ubuntu#gi' /etc/apt/sources.list
-
 # Update the box
 apt-get -y update >/dev/null
 apt-get -y install facter linux-headers-$(uname -r) build-essential zlib1g-dev libssl-dev libreadline-gplv2-dev curl unzip >/dev/null

--- a/ubuntu-14.04-x86_64/scripts/base.sh
+++ b/ubuntu-14.04-x86_64/scripts/base.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-perl -p -i -e 's#http://us.archive.ubuntu.com/ubuntu#http://mirror.rackspace.com/ubuntu#gi' /etc/apt/sources.list
-
 # Update the box
 apt-get -y update >/dev/null
 apt-get -y install facter linux-headers-$(uname -r) build-essential zlib1g-dev libssl-dev libreadline-gplv2-dev curl unzip >/dev/null


### PR DESCRIPTION
The Ubuntu LTS versions should provide adequate and safe packages for each distribution.

In my view, changing the mirror can cause future problems, especially for servers that are not in RackSpace.

It is safer to keep the original mirror.