### PR TITLE
Add qemu builder for ubuntu-14.04-x86_64

### DIFF
--- a/ubuntu-14.04-x86_64/template.json
+++ b/ubuntu-14.04-x86_64/template.json
@@ -21,6 +21,9 @@
                 },
                 "vmware-iso": {
                     "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+                },
+                "qemu": {
+                    "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
                 }
             }
         }
@@ -116,6 +119,35 @@
                 ["set", "{{.Name}}", "--memsize", "2048"],
                 ["set", "{{.Name}}", "--cpus", "4"]
             ]
+        },
+        {
+            "type": "qemu",
+            "boot_command": [
+                "<esc><esc><enter><wait>",
+                "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+                "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+                "hostname={{ .Name }} ",
+                "fb=false debconf/frontend=noninteractive ",
+                "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+                "initrd=/install/initrd.gz -- <enter>"
+            ],
+            "boot_wait": "10s",
+            "disk_size": 20480,
+            "http_directory": "http",
+            "iso_checksum": "a3b345908a826e262f4ea1afeb357fd09ec0558cf34e6c9112cead4bb55ccdfb",
+            "iso_checksum_type": "sha256",
+            "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.3-server-amd64.iso",
+            "ssh_username": "vagrant",
+            "ssh_password": "vagrant",
+            "ssh_port": 22,
+            "ssh_wait_timeout": "10000s",
+            "shutdown_command": "echo '/sbin/halt -h -p' > shutdown.sh; echo 'vagrant'|sudo -S bash 'shutdown.sh'",
+            "format": "qcow2",
+            "accelerator": "kvm",
+            "ssh_host_port_min": 2222,
+            "ssh_host_port_max": 2229,
+            "net_device": "virtio-net",
+            "disk_interface": "virtio"
         }
     ],
     "post-processors": [


### PR DESCRIPTION
Hi. I want suppport for libvirt on Fedora 22.

Could this PR be enough so you can upload a libvirt-compatible ubuntu image to hashicorp?
