### PR TITLE
Disk size to 100GB

### DIFF
--- a/centos-6-x86_64/template.json
+++ b/centos-6-x86_64/template.json
@@ -31,7 +31,7 @@
                 "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
             ],
             "boot_wait": "10s",
-            "disk_size": 20480,
+            "disk_size": 102400,
             "guest_os_type": "RedHat_64",
             "http_directory": "http",
             "iso_checksum": "eb3c8be6ab668e6d83a118323a789e6c",

--- a/centos-7-x86_64/template.json
+++ b/centos-7-x86_64/template.json
@@ -31,7 +31,7 @@
                 "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
             ],
             "boot_wait": "10s",
-            "disk_size": 20480,
+            "disk_size": 102400,
             "guest_os_type": "RedHat_64",
             "http_directory": "http",
             "iso_checksum": "d07ab3e615c66a8b2e9a50f4852e6a77",

--- a/debian-7-x86/template.json
+++ b/debian-7-x86/template.json
@@ -46,7 +46,7 @@
                 "<enter><wait>"
             ],
             "boot_wait": "10s",
-            "disk_size": 20480,
+            "disk_size": 102400,
             "guest_os_type": "Debian",
             "http_directory": "http",
             "iso_checksum": "27e88991ef6b4a7c9f929522a6833f1d",

--- a/debian-7-x86_64/template.json
+++ b/debian-7-x86_64/template.json
@@ -51,7 +51,7 @@
                 "<enter><wait>"
             ],
             "boot_wait": "10s",
-            "disk_size": 32768,
+            "disk_size": 102400,
             "guest_os_type": "Debian_64",
             "http_directory": "http",
             "iso_checksum_type": "none",

--- a/ubuntu-12.04-x86_64/template.json
+++ b/ubuntu-12.04-x86_64/template.json
@@ -38,7 +38,7 @@
                 "initrd=/install/initrd.gz -- <enter>"
             ],
             "boot_wait": "10s",
-            "disk_size": 20480,
+            "disk_size": 102400,
             "guest_os_type": "Ubuntu_64",
             "http_directory": "http",
             "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",

--- a/ubuntu-14.04-x86/template.json
+++ b/ubuntu-14.04-x86/template.json
@@ -38,7 +38,7 @@
                 "initrd=/install/initrd.gz -- <enter>"
             ],
             "boot_wait": "10s",
-            "disk_size": 20480,
+            "disk_size": 102400,
             "guest_os_type": "Ubuntu",
             "http_directory": "http",
             "iso_checksum": "a5c02e25a8f6ab335269adb1a6c176edff075093b90854439b4a90fce9b31f28",

--- a/ubuntu-14.04-x86_64/template.json
+++ b/ubuntu-14.04-x86_64/template.json
@@ -38,7 +38,7 @@
                 "initrd=/install/initrd.gz -- <enter>"
             ],
             "boot_wait": "10s",
-            "disk_size": 20480,
+            "disk_size": 102400,
             "guest_os_type": "Ubuntu_64",
             "http_directory": "http",
             "iso_checksum": "a3b345908a826e262f4ea1afeb357fd09ec0558cf34e6c9112cead4bb55ccdfb",


### PR DESCRIPTION
Why use 20GB disks? I have projects with big databases and they need bigger disks. Since only used HD space is allocated, there is no reason to keep this number small. It might even be more than 100GB, but I think 100GB will suffice most of the time.
